### PR TITLE
fix: remove emoji as command name

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
-    "🚘": "./bin.js",
     "ipfs-car": "./bin.js"
   },
   "repository": {


### PR DESCRIPTION
This may be causing issues on windows and I'm not convinced anyone actually uses it.