### PR TITLE
chore!: default to 1MiB chunks and 1024 children

### DIFF
--- a/unixfs.js
+++ b/unixfs.js
@@ -1,5 +1,7 @@
 /* eslint-env browser */
 import * as UnixFS from '@ipld/unixfs'
+import { withMaxChunkSize } from '@ipld/unixfs/file/chunker/fixed'
+import { withWidth } from '@ipld/unixfs/file/layout/balanced'
 import * as raw from 'multiformats/codecs/raw'
 
 const SHARD_THRESHOLD = 1000 // shard directory after > 1,000 items
@@ -7,7 +9,9 @@ const queuingStrategy = UnixFS.withCapacity()
 
 const defaultSettings = UnixFS.configure({
   fileChunkEncoder: raw,
-  smallFileEncoder: raw
+  smallFileEncoder: raw,
+  chunker: withMaxChunkSize(1024 * 1024),
+  fileLayout: withWidth(1024)
 })
 
 /**


### PR DESCRIPTION
## Background

Users often find it confusing that the same data results in a different UnixFS DAG and by extension a different CID.  This has been discussed at length in the [following forums thread](https://discuss.ipfs.tech/t/should-we-profile-cids/18507/37).

## What's in this PR

This PR, updates the defaults used by ipfs-car to match [the Storacha client, which is used by the w3up CLI](https://github.com/storacha/upload-service/blob/23a75e5c9b91bd102d7107fa120c4c6619c56f81/packages/upload-client/src/unixfs.js#L9-L14)

