### PR TITLE
feat(ipfs-car): avoid recursive writes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@ipld/dag-pb": "^4.0.2",
         "@ipld/unixfs": "^3.0.0",
         "@web3-storage/car-block-validator": "^1.0.1",
-        "files-from-path": "^1.0.0",
+        "files-from-path": "^1.1.5-rc.1",
         "ipfs-unixfs-exporter": "^13.0.1",
         "multiformats": "^13.0.1",
         "sade": "^1.8.1",
@@ -2679,9 +2679,9 @@
       }
     },
     "node_modules/files-from-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.0.tgz",
-      "integrity": "sha512-EobUbrzh1fPOZpQvDdTikGpCs+ZDcTNyBOnFuHvW2BQXEkMSPbEPQ0eVTQrz0oHlBcPS9Lnw+uPzACfft1sDYg==",
+      "version": "1.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.1.5-rc.1.tgz",
+      "integrity": "sha512-BfaE1Vyl03WdY7rIo9XADadtv4MigWZNczZApZjmlct7RlnGbvCtpQXs3zUOqhgAuPSuf+oTTNyo3FToIn5VxQ==",
       "dependencies": {
         "graceful-fs": "^4.2.10"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ipld/dag-pb": "^4.0.2",
     "@ipld/unixfs": "^3.0.0",
     "@web3-storage/car-block-validator": "^1.0.1",
-    "files-from-path": "^1.0.0",
+    "files-from-path": "^1.1.5-rc.1",
     "ipfs-unixfs-exporter": "^13.0.1",
     "multiformats": "^13.0.1",
     "sade": "^1.8.1",


### PR DESCRIPTION
fix #174

if output file exists in source path, just overwrite it, but don't include it in the packed car file

requires https://github.com/storacha/files-from-path/pull/46