### PR TITLE
feat(cli): hash can output a base58btc encoded multihash

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -53,6 +53,7 @@ cli
 cli
   .command('hash [car]')
   .describe('Generate CID for a CAR.')
+  .option('-m, --only-multihash', 'Output base58btc encoded multihash instead of a CID.')
   .action(createAction('./cmd/hash.js'))
 
 cli.parse(process.argv)

--- a/cmd/hash.js
+++ b/cmd/hash.js
@@ -4,12 +4,16 @@ import { pipeline } from 'stream/promises'
 import { CID } from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
 import { sha256 } from 'multiformats/hashes/sha2'
+import { base58btc } from 'multiformats/bases/base58'
 
 /** CAR CID code */
 const carCode = 0x0202
 
-/** @param {string} carPath */
-export default async function hash (carPath) {
+/**
+ * @param {string} carPath
+ * @param {{ 'only-multihash': boolean }} [opts]
+ */
+export default async function hash (carPath, opts) {
   const hasher = crypto.createHash('sha256')
 
   await pipeline(
@@ -22,5 +26,9 @@ export default async function hash (carPath) {
   )
 
   const digest = Digest.create(sha256.code, hasher.digest())
-  console.log(CID.createV1(carCode, digest).toString())
+  if (opts?.['only-multihash']) {
+    console.log(base58btc.encode(digest.bytes))
+  } else {
+    console.log(CID.createV1(carCode, digest).toString())
+  }
 }

--- a/test/bin.node.test.js
+++ b/test/bin.node.test.js
@@ -248,6 +248,12 @@ describe('CLI', function () {
     assert.equal(res.stdout, 'bagbaieraycsgjotn63wc2tdyiyadvkdach5vphpdmoeehnseebjbtapgi44q')
   })
 
+  it('generate multihash', () => {
+    const carPath = './test/fixtures/comic.car'
+    const res = execaSync(binPath, ['hash', carPath, '--only-multihash'])
+    assert.equal(res.stdout, 'zQmbJeNsbY4jTphnsZ4RBHG2jC8STcBanGVPi3V3A9FQxSU')
+  })
+
   it('stdin | generate CAR CID', () => {
     const carPath = './test/fixtures/comic.car'
     const res = execaSync(binPath, ['hash'], {


### PR DESCRIPTION
Pass `-m` or `--only-multihash` to instruct `ipfs-car hash` to output a base58btc encoded multihash instead of a CID.

e.g.

```console
$ ipfs-car hash ./test/fixtures/comic.car --only-multihash
zQmbJeNsbY4jTphnsZ4RBHG2jC8STcBanGVPi3V3A9FQxSU
```